### PR TITLE
CI: update Go(lang) version in github/workflow/makefile.yml

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -15,7 +15,7 @@ jobs:
      - name: Setup Go
        uses: actions/setup-go@v3
        with:
-          go-version: "1.18.0"
+          go-version: "1.20.0"
           
      - uses: actions/checkout@v2
       


### PR DESCRIPTION
This PR updates the version of Go used in CI (i.e., within the GitHub workflows)